### PR TITLE
Added PUT and POST body support

### DIFF
--- a/addon/mixins/fetch-support.js
+++ b/addon/mixins/fetch-support.js
@@ -57,13 +57,17 @@ export default Mixin.create({
     return cookie.join('; ');
   },
 
-  _createInit(type, headers) {
+  _createInit(type, headers, body) {
     headers = assign({}, get(this, 'headers'), headers);
 
     let init = {
       method: type,
       headers
     };
+
+    if (body) {
+      init.body = body;
+    }
 
     if (isFastBoot()) {
       headers.cookie = this._createCookieString();
@@ -75,12 +79,20 @@ export default Mixin.create({
   },
 
   ajax(url, type, options) {
-    let qs = this._convertDataToQueryString(options.data);
-    if (qs) {
-      url += `?${qs}`;
+    let body;
+    switch (type) {
+      case 'PUT':
+      case 'POST':
+        body = options.data;
+        break;
+      default:
+        let qs = this._convertDataToQueryString(options.data);
+        if (qs) {
+          url += `?${qs}`;
+        }
     }
 
-    let init = this._createInit(type, options.headers);
+    let init = this._createInit(type, options.headers, body);
 
     return get(this, 'fetch').fetch(url, init).then(response => {
       return response.json();

--- a/tests/unit/mixins/fetch-support-test.js
+++ b/tests/unit/mixins/fetch-support-test.js
@@ -9,9 +9,9 @@ const {
 } = Ember;
 
 const url = 'test/url';
-const type = 'TEST_METHOD';
 const query = 'test=query';
 
+let type;
 let sandbox;
 let jsonResponse;
 let fetch;
@@ -52,6 +52,7 @@ module('Unit | Mixin | fetch support', {
     });
     subject = FetchSupportObject.create();
 
+    type = 'TEST_METHOD';
     data = {
       test: 'data'
     };
@@ -188,5 +189,21 @@ test('it sets cookie header when fastboot', function(assert) {
 test('it returns json from fetch', function(assert) {
   return ajax().then(result => {
     assert.strictEqual(result, jsonResponse);
+  });
+});
+
+test('it passes the data as body and not qs for PUT', function(assert) {
+  type = 'PUT';
+  return ajax().then(() => {
+    assert.strictEqual(fetch.args[0][1].body, data);
+    assert.strictEqual(fetch.args[0][0], url);
+  });
+});
+
+test('it passes the data as body and not qs for POST', function(assert) {
+  type = 'POST';
+  return ajax().then(() => {
+    assert.strictEqual(fetch.args[0][1].body, data);
+    assert.strictEqual(fetch.args[0][0], url);
   });
 });


### PR DESCRIPTION
PUT and POST requests put the `data` option into `body` for fetch. Previously all requests put the `data` option into the query string.
