### PR TITLE
Remove 'init.credentials'. The header 'credentials' can be included …

### DIFF
--- a/addon/mixins/fetch-support.js
+++ b/addon/mixins/fetch-support.js
@@ -79,8 +79,6 @@ export default Mixin.create({
 
     if (isFastBoot()) {
       headers.cookie = this._createCookieString();
-    } else {
-      init.credentials = 'include';
     }
 
     return init;


### PR DESCRIPTION
…via the adapter. Closes #23 that I opened.


```
export default JSONAPIAdapter.extend(FetchSupport, {
    host: 'https://...',
    namespace: '/',
    headers: {
        Authorization: '...',
        credentials: 'include'
    }
});
```